### PR TITLE
Cm/contingent features

### DIFF
--- a/schemas/ContingentFeatureMarkers.json
+++ b/schemas/ContingentFeatureMarkers.json
@@ -25,7 +25,7 @@
       "items": {
         "type": "string"
       },
-      "description": "List of inflectional features this set expones."
+      "description": "List of features in the order they are nested in the markers object."
     },
     "global_stage": {
       "type": "string",
@@ -39,30 +39,28 @@
       "description": "A marker or list of markers applied to all forms in this paradigm."
     },
     "markers": {
-      "type": "array",
-      "description": "An array over feature vectors and their realizations.",
-      "items": {
-        "type": "object",
-        "required": [
-          "features",
-          "realization"
-        ],
-        "properties": {
-          "features": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "The feature value vector specified for this marker group."
-          },
-          "realization": {
-            "type": "array",
-            "items": {
-              "$ref": "./FeatureMarkers.json#/definitions/marker"
-            }
+      "$ref": "#/definitions/nested_markers"
+    }
+  },
+  "definitions": {
+    "nested_markers": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "./FeatureMarkers.json#/definitions/marker"
+          }
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/nested_markers"
           }
         }
-      }
+      ]
     }
   }
 }

--- a/src/grammar/marker_resolution.py
+++ b/src/grammar/marker_resolution.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from loguru import logger
 
-from src.lexicon import get_roots, get_principal_part_for_all_roots
+from src.lexicon import get_roots, get_principal_part_for_all_roots, get_features_for_root
 from src.yaml_utils.models import (
     Marker,
     UnorderedMarker,
@@ -27,6 +27,7 @@ def get_markers_for_paradigm(
     feature_values: FeatureComboType | dict[str, str],
     paradigm_name: str,
     include_features: bool = False,
+    root: str | None = None,
 ) -> list[Marker] | list[tuple[Marker, FeatureComboType | str]]:
     """
     Get all markers for a requested feature set for a given paradigm.
@@ -55,10 +56,21 @@ def get_markers_for_paradigm(
             f"Feature values {feature_values} not valid for paradigm {paradigm_name}"
         )
 
+    part_of_speech = paradigm_data["part_of_speech"]
+    part_of_speech_data = get_yaml_data_safe(
+        yaml_basename=part_of_speech, kind="PartOfSpeech"
+    )
+    lexical_feature_names = set(part_of_speech_data.get("lexical_features", []))
+
+    if root:
+        lexical_features = set(get_features_for_root(part_of_speech, root))
+        feature_values |= lexical_features
+
     markers = get_markers(
         feature_marker_files=marker_files,
         contingent_feature_marker_files=contingent_files,
         feature_values=feature_values,
+        lexical_feature_names=lexical_feature_names,
     )
 
     # any global markers defined in the paradigm should be applied to all feature combinations
@@ -136,10 +148,16 @@ def get_free_features_for_paradigm(
     name: str, kind: str = "Paradigm"
 ) -> list[str]:
     paradigm_data = get_yaml_data_safe(kind=kind, yaml_basename=name)
-    free_features = []
-    for feature, value in paradigm_data["feature_markers"].items():
-        if isinstance(value, str) and value.startswith("$"):
-            free_features.append(feature)
+    part_of_speech = paradigm_data["part_of_speech"]
+    part_of_speech_data = get_yaml_data_safe(
+        yaml_basename=part_of_speech, kind="PartOfSpeech"
+    )
+    free_features = list(part_of_speech_data.get("features", []))
+
+    for feature, value in paradigm_data.get("feature_markers", {}).items():
+        if value is not None and not (isinstance(value, str) and value.startswith("$")):
+            if feature in free_features:
+                free_features.remove(feature)
 
     return free_features
 
@@ -178,7 +196,8 @@ def get_feature_combos_for_paradigm(
             marker_files.append(ref)
         else:
             fixed[feature_name] = ref
-            free_feature_names.remove(feature_name)
+            if feature_name in free_feature_names:
+                free_feature_names.remove(feature_name)
 
     contingent_files = list(paradigm_data.get("contingent_markers", []))
 

--- a/src/grammar/paradigm_compilation.py
+++ b/src/grammar/paradigm_compilation.py
@@ -117,7 +117,7 @@ def build_inflect_graph(paradigm_name: str) -> pynini.Fst:
         for feature_values in combos:
             try:
                 markers = get_markers_for_paradigm(
-                    feature_values, paradigm_name)
+                    feature_values, paradigm_name, root=root)
                 inflected_output = pynini.project(
                     _apply_markers(root_fsa, markers), project_type="output"
                 )
@@ -356,7 +356,7 @@ def inflect_stages(
         )
 
     marker_tuples = get_markers_for_paradigm(
-        feature_values, name, include_features=True
+        feature_values, name, include_features=True, root=root
     )
 
     initial_stage = InflectStage(

--- a/src/yaml_utils/yaml_server.py
+++ b/src/yaml_utils/yaml_server.py
@@ -390,6 +390,7 @@ def get_markers(
     feature_marker_files: list[str],
     contingent_feature_marker_files: list[str],
     feature_values: set[tuple[str, str]] | dict[str, str],
+    lexical_feature_names: set[str] | None = None,
 ) -> list[tuple[Marker, FeatureComboType]]:
     """
     Query all specified files for markers exponing the requested feature set.
@@ -408,7 +409,10 @@ def get_markers(
     if not feature_values:
         return []
 
-    unexponed_features = {feature for feature, _ in feature_values}
+    if lexical_feature_names is None:
+        lexical_feature_names = set()
+
+    unexponed_features = {feature for feature, _ in feature_values if feature not in lexical_feature_names}
     markers = []
 
     # iterate through contingent feature markers and attempt
@@ -416,17 +420,19 @@ def get_markers(
     # since contingent markers can overlap, order of iteration does not matter
     for contingent_file in contingent_feature_marker_files:
         data = get_yaml_data_safe("ContingentFeatureMarkers", contingent_file)
-        markers_for_file = _get_valid_contingent_markers(data, feature_values)
-        if markers_for_file:
-            contingent_feature_names = data["features"]
+        result = _get_valid_contingent_markers(data, feature_values)
+        if result is not None:
+            realization, matched_features = result
+            contingent_feature_names = data.get("features", [])
+            
+            inflectional_contingent_names = [f for f in contingent_feature_names if f not in lexical_feature_names]
+            unexponed_features -= set(inflectional_contingent_names)
+            
             contingent_feature_values = {
-                value
-                for feature, value in feature_values
-                if feature in contingent_feature_names
+                (f, v) for f, v in matched_features if f not in lexical_feature_names
             }
-            unexponed_features -= set(contingent_feature_names)
             markers.extend(
-                (marker, contingent_feature_values) for marker in markers_for_file
+                (marker, contingent_feature_values) for marker in realization
             )
 
     # attempt to match any remaining features with regular feature markers
@@ -459,17 +465,36 @@ def get_markers(
 
 
 def _get_valid_contingent_markers(
-    data: dict, feature_values: set[FeatureValue]
-) -> tuple[tuple[Marker], set[FeatureValue]] | None:
+    data: dict,
+    feature_values: set[tuple[str, str]] | dict[str, str],
+) -> tuple[list[Marker], set[tuple[str, str]]] | None:
     """
-    Attempt to find a valid contingent marker which is a subset of the requested features.
+    Attempt to find a valid contingent marker which matches the requested features.
     """
-    for marker in data["markers"]:
-        marker_features = set(marker["features"].items())
+    lookup = dict(feature_values)
+    features_list = data.get("features", [])
+    if not features_list:
+        return None
 
-        if marker_features.issubset(feature_values):
-            return marker["realization"], marker_features
-    return None
+    curr = data.get("markers", {})
+    matched_features = set()
+
+    for f in features_list:
+        if f not in lookup:
+            return None
+        val = lookup[f]
+        if not isinstance(curr, dict) or val not in curr:
+            return None
+        curr = curr[val]
+        matched_features.add((f, val))
+
+    if curr is None:
+        return [], matched_features
+
+    if not isinstance(curr, list):
+        return None
+
+    return curr, matched_features
 
 
 def kind_dir(kind: str) -> str:

--- a/tests/transduction_test.py
+++ b/tests/transduction_test.py
@@ -138,3 +138,110 @@ def test_2sg_a_class():
     form_hits = [hit["form"] for hit in search_result]
     assert "habl-as" in form_hits
     assert "habl-o" in form_hits
+
+
+def test_contingent_lexical_submapping():
+    from src.constants import get_yaml_dir
+    from src.yaml_utils.yaml_server import get_yaml_data_safe, get_feature_map
+    import yaml
+    
+    yaml_dir = get_yaml_dir()
+    contingent_dir = os.path.join(yaml_dir, "Exponence", "ContingentFeatureMarkers")
+    paradigm_dir = os.path.join(yaml_dir, "Morphotactics", "Paradigm")
+    
+    contingent_path = os.path.join(contingent_dir, "class_test_contingent.yaml")
+    paradigm_path = os.path.join(paradigm_dir, "verb_class_test.yaml")
+    
+    verb_pos = get_yaml_data_safe(kind="PartOfSpeech", yaml_basename="verb")
+    lex_feats = verb_pos.get("lexical_features", [])
+    pos_feats = verb_pos.get("features", [])
+
+    if "conjugation_class" in lex_feats:
+        class_name = "conjugation_class"
+        feature = "person_number"
+        class1, class2 = "a_class", "e_class"
+        root1, root2 = "habl", "com"
+        val1_1, val1_2 = "-o_a", "-as_a"
+        val2_1, val2_2 = "-o_e", "-es_e"
+        feat_markers = {
+            "person_number": None,
+            "tense": "present",
+            "mood": "indicative"
+        }
+    elif "prefix_class" in lex_feats:
+        class_name = "prefix_class"
+        feature = "aspect" if "aspect" in pos_feats else "person_number"
+        class1, class2 = "a_stem", "cons_stem"
+        root1, root2 = "atvn", "woni"
+        val1_1, val1_2 = "-o_a", "-as_a"
+        val2_1, val2_2 = "-o_e", "-es_e"
+        feat_markers = {feature: None}
+        for f in pos_feats:
+            if f != feature:
+                fmap = get_feature_map()
+                feat_markers[f] = fmap[f][0] if f in fmap and fmap[f] else "unmarked"
+    else:
+        pytest.skip("No recognized lexical features for testing")
+        return
+
+    fmap = get_feature_map()
+    feat_vals = fmap.get(feature, ["1sg", "2sg"])
+    val_key1 = feat_vals[0]
+    val_key2 = feat_vals[1] if len(feat_vals) > 1 else "unmarked"
+
+    contingent_data = {
+        "kind": "ContingentFeatureMarkers",
+        "features": [class_name, feature],
+        "markers": {
+            class1: {
+                val_key1: [{"kind": "suffix", "value": val1_1}],
+                val_key2: [{"kind": "suffix", "value": val1_2}]
+            },
+            class2: {
+                val_key1: [{"kind": "suffix", "value": val2_1}],
+                val_key2: [{"kind": "suffix", "value": val2_2}]
+            }
+        }
+    }
+    
+    paradigm_data = {
+        "kind": "Paradigm",
+        "part_of_speech": "$verb",
+        "feature_markers": feat_markers,
+        "contingent_markers": [
+            "$class_test_contingent"
+        ]
+    }
+    
+    os.makedirs(contingent_dir, exist_ok=True)
+    os.makedirs(paradigm_dir, exist_ok=True)
+    
+    with open(contingent_path, "w", encoding="utf-8") as f:
+        yaml.dump(contingent_data, f)
+        
+    with open(paradigm_path, "w", encoding="utf-8") as f:
+        yaml.dump(paradigm_data, f)
+        
+    try:
+        _get_or_build(graph_type="inflect", paradigm_name="verb_class_test", force_rebuild=True)
+        
+        # Test root1
+        res_root1_1 = inflect(root1, {feature: val_key1}, "verb_class_test")
+        assert f"{root1}{val1_1}" in res_root1_1
+        
+        res_root1_2 = inflect(root1, {feature: val_key2}, "verb_class_test")
+        assert f"{root1}{val1_2}" in res_root1_2
+        
+        # Test root2
+        res_root2_1 = inflect(root2, {feature: val_key1}, "verb_class_test")
+        assert f"{root2}{val2_1}" in res_root2_1
+        
+        res_root2_2 = inflect(root2, {feature: val_key2}, "verb_class_test")
+        assert f"{root2}{val2_2}" in res_root2_2
+        
+    finally:
+        if os.path.exists(contingent_path):
+            os.remove(contingent_path)
+        if os.path.exists(paradigm_path):
+            os.remove(paradigm_path)
+

--- a/tests/transduction_test.py
+++ b/tests/transduction_test.py
@@ -25,9 +25,12 @@ import pynini
 
 from src.yaml_utils.yaml_server import get_yaml_data_safe
 from src.grammar.paradigm_compilation import inflect, parse, search, _get_or_build
+from src.constants import get_yaml_dir
+from src.yaml_utils.yaml_server import get_yaml_data_safe, get_feature_map
 
 from src.constants import PROJECT_ROOT
 import os
+import yaml
 import pytest
 
 
@@ -95,8 +98,7 @@ def test_2sg_a_class():
     part_of_speech = get_yaml_data_safe(kind="Paradigm", yaml_basename="$verb_a_stem")[
         "part_of_speech"
     ]
-    roots = get_roots_with_gloss(
-        lexicon_basename=part_of_speech, gloss="speak")
+    roots = get_roots_with_gloss(lexicon_basename=part_of_speech, gloss="speak")
     assert roots == ["habl"]
 
     root = roots[0]
@@ -111,16 +113,14 @@ def test_2sg_a_class():
 
     # here we invalidate the cache whenever the test is run
     # TODO: directly test automatic cache invalidation when source files are changed
-    _get_or_build(graph_type="inflect",
-                  paradigm_name="verb_a_stem", force_rebuild=True)
+    _get_or_build(graph_type="inflect", paradigm_name="verb_a_stem", force_rebuild=True)
 
     inflect_result = inflect(
         root=root, feature_values=feature_values, name="verb_a_stem"
     )
     assert inflect_result == result_strings
 
-    _get_or_build(graph_type="parse",
-                  paradigm_name="verb_a_stem", force_rebuild=True)
+    _get_or_build(graph_type="parse", paradigm_name="verb_a_stem", force_rebuild=True)
 
     parse_result = parse(expected_form, kind="Paradigm", name="verb_a_stem")
     expected_parse = {
@@ -141,17 +141,14 @@ def test_2sg_a_class():
 
 
 def test_contingent_lexical_submapping():
-    from src.constants import get_yaml_dir
-    from src.yaml_utils.yaml_server import get_yaml_data_safe, get_feature_map
-    import yaml
-    
+
     yaml_dir = get_yaml_dir()
     contingent_dir = os.path.join(yaml_dir, "Exponence", "ContingentFeatureMarkers")
     paradigm_dir = os.path.join(yaml_dir, "Morphotactics", "Paradigm")
-    
+
     contingent_path = os.path.join(contingent_dir, "class_test_contingent.yaml")
     paradigm_path = os.path.join(paradigm_dir, "verb_class_test.yaml")
-    
+
     verb_pos = get_yaml_data_safe(kind="PartOfSpeech", yaml_basename="verb")
     lex_feats = verb_pos.get("lexical_features", [])
     pos_feats = verb_pos.get("features", [])
@@ -163,11 +160,7 @@ def test_contingent_lexical_submapping():
         root1, root2 = "habl", "com"
         val1_1, val1_2 = "-o_a", "-as_a"
         val2_1, val2_2 = "-o_e", "-es_e"
-        feat_markers = {
-            "person_number": None,
-            "tense": "present",
-            "mood": "indicative"
-        }
+        feat_markers = {"person_number": None, "tense": "present", "mood": "indicative"}
     elif "prefix_class" in lex_feats:
         class_name = "prefix_class"
         feature = "aspect" if "aspect" in pos_feats else "person_number"
@@ -195,53 +188,52 @@ def test_contingent_lexical_submapping():
         "markers": {
             class1: {
                 val_key1: [{"kind": "suffix", "value": val1_1}],
-                val_key2: [{"kind": "suffix", "value": val1_2}]
+                val_key2: [{"kind": "suffix", "value": val1_2}],
             },
             class2: {
                 val_key1: [{"kind": "suffix", "value": val2_1}],
-                val_key2: [{"kind": "suffix", "value": val2_2}]
-            }
-        }
+                val_key2: [{"kind": "suffix", "value": val2_2}],
+            },
+        },
     }
-    
+
     paradigm_data = {
         "kind": "Paradigm",
         "part_of_speech": "$verb",
         "feature_markers": feat_markers,
-        "contingent_markers": [
-            "$class_test_contingent"
-        ]
+        "contingent_markers": ["$class_test_contingent"],
     }
-    
+
     os.makedirs(contingent_dir, exist_ok=True)
     os.makedirs(paradigm_dir, exist_ok=True)
-    
+
     with open(contingent_path, "w", encoding="utf-8") as f:
         yaml.dump(contingent_data, f)
-        
+
     with open(paradigm_path, "w", encoding="utf-8") as f:
         yaml.dump(paradigm_data, f)
-        
+
     try:
-        _get_or_build(graph_type="inflect", paradigm_name="verb_class_test", force_rebuild=True)
-        
+        _get_or_build(
+            graph_type="inflect", paradigm_name="verb_class_test", force_rebuild=True
+        )
+
         # Test root1
         res_root1_1 = inflect(root1, {feature: val_key1}, "verb_class_test")
         assert f"{root1}{val1_1}" in res_root1_1
-        
+
         res_root1_2 = inflect(root1, {feature: val_key2}, "verb_class_test")
         assert f"{root1}{val1_2}" in res_root1_2
-        
+
         # Test root2
         res_root2_1 = inflect(root2, {feature: val_key1}, "verb_class_test")
         assert f"{root2}{val2_1}" in res_root2_1
-        
+
         res_root2_2 = inflect(root2, {feature: val_key2}, "verb_class_test")
         assert f"{root2}{val2_2}" in res_root2_2
-        
+
     finally:
         if os.path.exists(contingent_path):
             os.remove(contingent_path)
         if os.path.exists(paradigm_path):
             os.remove(paradigm_path)
-


### PR DESCRIPTION
I had issues getting this to work as is, so I thought I'd PR the changes I ended up making. If there was a way to accomplish this with the existing schema I'd love to make what already exists work!

This PR allows for contingent features to be defined like below.

`features` gives the list of features that will be nested, starting with outermost.

`markers` contains a dict nested by the values for each `feature`.

```yaml
# This is a ContingentFeatureMarkers config file
# Generated automatically from CSVs
kind: ContingentFeatureMarkers
features:
- aspect_class
- aspect
markers:
  be-at:
    completive:
    - kind: suffix
      value: ol
      stage: aspect_suffix
    immediate:
    - kind: suffix
      value: oh
      stage: aspect_suffix
    incompletive:
    - kind: suffix
      value: a
      stage: aspect_suffix
    infinitive:
    - kind: suffix
      value: ahst
      stage: aspect_suffix
    present:
    - kind: suffix
      value: oha
      stage: aspect_suffix
  e-a:
    completive:
    - kind: suffix
      value: a
      stage: aspect_suffix
    immediate:
    - kind: suffix
      value: esk
      stage: aspect_suffix
    incompletive:
    - kind: suffix
      value: e'
      stage: aspect_suffix
    infinitive:
    - kind: suffix
      value: et
      stage: aspect_suffix
    present:
    - kind: suffix
      value: e'a
      stage: aspect_suffix
 ```